### PR TITLE
fix: dashboard provider key retention, config hot-reload, version display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cortex",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.4",
   "description": "Cortex - Universal AI Agent Memory Service",
   "scripts": {
     "dev": "pnpm --filter @cortex/server dev",

--- a/packages/dashboard/src/pages/Settings/index.tsx
+++ b/packages/dashboard/src/pages/Settings/index.tsx
@@ -39,6 +39,8 @@ export default function Settings() {
   const [draft, setDraft] = useState<any>({});
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const [testState, setTestState] = useState<Record<string, { status: 'idle' | 'testing' | 'success' | 'error'; message?: string; latency?: number }>>({});
+  // Store API keys per (prefix, provider) so switching providers doesn't lose entered keys
+  const [savedKeys, setSavedKeys] = useState<Record<string, string>>({});
   const [logLevel, setLogLevelState] = useState('info');
   const { t } = useI18n();
 
@@ -689,6 +691,11 @@ export default function Settings() {
     const isDisabled = provider === 'none';
 
     const handleProviderChange = (newProvider: string) => {
+      // Save the current provider's API key before switching
+      const currentKey = d.apiKey;
+      if (currentKey) {
+        setSavedKeys(prev => ({ ...prev, [`${prefix}::${provider}`]: currentKey }));
+      }
       updateDraft(`${prefix}.provider`, newProvider);
       const newPreset = providerMap[newProvider];
       const firstModel = newPreset?.models?.[0] ?? '';
@@ -696,6 +703,9 @@ export default function Settings() {
       updateDraft(`${prefix}.useCustomModel`, false);
       updateDraft(`${prefix}.customModel`, '');
       updateDraft(`${prefix}.baseUrl`, '');
+      // Restore previously saved key for the new provider (if any)
+      const restoredKey = savedKeys[`${prefix}::${newProvider}`] ?? '';
+      updateDraft(`${prefix}.apiKey`, restoredKey);
       // Auto-update dimensions for embedding models
       if (d.dimensions !== undefined && firstModel && EMBEDDING_DIMENSIONS[firstModel]) {
         updateDraft(`${prefix}.dimensions`, EMBEDDING_DIMENSIONS[firstModel]);

--- a/packages/server/src/api/system.ts
+++ b/packages/server/src/api/system.ts
@@ -21,8 +21,8 @@ function getPackageVersion(): string {
       const p = path.resolve(__dirname, rel);
       if (fs.existsSync(p)) {
         const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
+        // Only return version from the root monorepo package, not sub-packages
         if (pkg.name === 'cortex' || pkg.name === '@cortex/root') return pkg.version;
-        if (pkg.version) return pkg.version;
       }
     }
   } catch {}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -79,11 +79,19 @@ export class CortexApp {
       log.info('Reloaded embedding provider');
     }
 
-    // Check if search/gate config changed (reranker, query expansion, etc.)
+    // Check if search/gate/sieve/lifecycle/markdownExport config changed
     const searchConfigChanged = JSON.stringify(this.config.search) !== JSON.stringify(newConfig.search);
     const gateConfigChanged = JSON.stringify(this.config.gate) !== JSON.stringify(newConfig.gate);
+    const sieveConfigChanged = JSON.stringify(this.config.sieve) !== JSON.stringify(newConfig.sieve);
+    const flushConfigChanged = JSON.stringify(this.config.flush) !== JSON.stringify(newConfig.flush);
+    const lifecycleConfigChanged = JSON.stringify(this.config.lifecycle) !== JSON.stringify(newConfig.lifecycle);
+    const exporterConfigChanged = JSON.stringify(this.config.markdownExport) !== JSON.stringify(newConfig.markdownExport);
     if (searchConfigChanged) reloaded.push('search');
     if (gateConfigChanged) reloaded.push('gate');
+    if (sieveConfigChanged) reloaded.push('sieve');
+    if (flushConfigChanged) reloaded.push('flush');
+    if (lifecycleConfigChanged) reloaded.push('lifecycle');
+    if (exporterConfigChanged) reloaded.push('markdownExport');
 
     // Rebuild dependent engines if any provider or config changed
     if (reloaded.length > 0) {
@@ -93,6 +101,7 @@ export class CortexApp {
       this.sieve = new MemorySieve(this.llmExtraction, this.embeddingProvider, this.vectorBackend, newConfig);
       this.flush = new MemoryFlush(this.llmExtraction, this.embeddingProvider, this.vectorBackend, newConfig);
       this.lifecycle = new LifecycleEngine(this.llmLifecycle, this.embeddingProvider, this.vectorBackend, newConfig);
+      this.exporter = new MarkdownExporter(newConfig);
       log.info({ reloaded }, 'Rebuilt dependent engines');
     }
 


### PR DESCRIPTION
## Changes

### 1. Version bump
- `0.9.2` → `0.9.4`

### 2. Dashboard: Remember API keys per provider
- 切换 embedding/search provider 时，自动保存当前 provider 的 API key
- 切换回来时自动恢复之前填过的 key
- 修复了从 Voyage 切到 OpenAI 后 key 没更新的问题

### 3. Config hot-reload improvements
- 新增 sieve、flush、lifecycle、markdownExport 配置变更检测
- 修复 MarkdownExporter 在配置变更时未重建的问题
- 现在修改 embedding provider/key 等配置后无需重启

### 4. Version display fix
- system API 只从 root monorepo 的 package.json 读取版本号
- 修复部署新版本后 API 仍显示旧版本的问题

Closes partially #12 (multi-agent isolation documentation to follow)