### PR TITLE
fix: dedupe Neo4j relations and cascade correction state

### DIFF
--- a/packages/server/src/core/memory-writer.ts
+++ b/packages/server/src/core/memory-writer.ts
@@ -40,6 +40,13 @@ class Semaphore {
   }
 }
 const smartUpdateSemaphore = new Semaphore(2);
+const CORRECTION_SEARCH_CATEGORIES: MemoryCategory[] = [
+  'identity', 'fact', 'preference', 'decision', 'entity', 'skill', 'relationship',
+  'goal', 'project_state', 'correction', 'todo', 'constraint', 'policy',
+];
+const CORRECTION_CASCADE_CATEGORIES = new Set<MemoryCategory>([
+  'todo', 'decision', 'goal', 'project_state', 'correction',
+]);
 
 export interface ExtractedMemory {
   content: string;
@@ -72,6 +79,50 @@ export class MemoryWriter {
     private vectorBackend: VectorBackend,
     private config: CortexConfig,
   ) {}
+
+  private getEffectiveThreshold(category: MemoryCategory): number {
+    const { similarityThreshold } = this.config.sieve;
+    return category === 'correction'
+      ? Math.min(similarityThreshold * 1.5, 0.6)
+      : similarityThreshold;
+  }
+
+  private getSearchCategories(category: MemoryCategory): MemoryCategory[] | undefined {
+    return category === 'correction' ? CORRECTION_SEARCH_CATEGORIES : undefined;
+  }
+
+  private getSearchTopK(category: MemoryCategory): number {
+    return category === 'correction' ? 10 : 3;
+  }
+
+  private cascadeCorrectionStateSupersedes(
+    newMemoryId: string,
+    similar: SimilarMemory[],
+    primaryTargetId: string,
+    threshold: number,
+  ): void {
+    for (const candidate of similar) {
+      if (candidate.memory.id === primaryTargetId) continue;
+      if (candidate.distance >= threshold) continue;
+      if (!CORRECTION_CASCADE_CATEGORIES.has(candidate.memory.category)) continue;
+      if (candidate.memory.superseded_by || candidate.memory.is_pinned) continue;
+
+      try {
+        const meta = JSON.parse(candidate.memory.metadata || '{}');
+        updateMemory(candidate.memory.id, {
+          superseded_by: newMemoryId,
+          metadata: JSON.stringify({
+            ...meta,
+            superseded_reason: 'correction_cascade',
+            superseded_by_correction: newMemoryId,
+            superseded_at: new Date().toISOString(),
+          }),
+        });
+      } catch {
+        updateMemory(candidate.memory.id, { superseded_by: newMemoryId });
+      }
+    }
+  }
 
   /**
    * Find similar memories via vector search.
@@ -303,6 +354,7 @@ export class MemoryWriter {
     confidenceOverride?: number,
     sourcePrefix = 'sieve',
     forceLayer?: 'working' | 'core',
+    pairingCode?: string,
   ): Promise<ProcessResult> {
     // Gate: filter obvious noise before expensive operations
     const minImportance = this.config.sieve.minImportance ?? 0.3;
@@ -319,24 +371,15 @@ export class MemoryWriter {
       return { action: 'skipped' };
     }
 
-    const { smartUpdate, exactDupThreshold, similarityThreshold } = this.config.sieve;
+    const { smartUpdate, exactDupThreshold } = this.config.sieve;
 
     // During lifecycle runs, skip smart update to avoid data races with deduplicateCore
     const effectiveSmartUpdate = smartUpdate && !isLifecycleActive();
 
-    // Corrections get a wider similarity window (1.5x)
-    const effectiveThreshold = extraction.category === 'correction'
-      ? Math.min(similarityThreshold * 1.5, 0.6)
-      : similarityThreshold;
-
-    // Corrections search within related categories
-    const correctionCategories = extraction.category === 'correction'
-      ? ['identity', 'fact', 'preference', 'decision', 'entity', 'skill', 'relationship', 'goal', 'project_state', 'correction']
-      : undefined;
-
-    // Corrections get wider search (top 10) to find the target memory
-    const topK = extraction.category === 'correction' ? 10 : 3;
-    const similar = await this.findSimilar(extraction.content, agentId, correctionCategories, topK);
+    const effectiveThreshold = this.getEffectiveThreshold(extraction.category);
+    const searchCategories = this.getSearchCategories(extraction.category);
+    const topK = this.getSearchTopK(extraction.category);
+    const similar = await this.findSimilar(extraction.content, agentId, searchCategories, topK);
 
     if (!effectiveSmartUpdate) {
       // Legacy behavior (or lifecycle active — skip smart update to avoid races)
@@ -372,6 +415,9 @@ export class MemoryWriter {
             { action: 'replace', reasoning: 'Near-exact match, auto-replaced without LLM' },
             closest.memory, extraction, agentId, sessionId, confidenceOverride, sourcePrefix,
           );
+          if (extraction.category === 'correction') {
+            this.cascadeCorrectionStateSupersedes(newMem.id, similar, closest.memory.id, effectiveThreshold);
+          }
           return { action: 'smart_updated', memory: newMem };
         }
 
@@ -392,6 +438,9 @@ export class MemoryWriter {
           const newMem = await this.executeSmartUpdate(
             decision, closest.memory, extraction, agentId, sessionId, confidenceOverride, sourcePrefix,
           );
+          if (extraction.category === 'correction') {
+            this.cascadeCorrectionStateSupersedes(newMem.id, similar, closest.memory.id, effectiveThreshold);
+          }
           return { action: 'smart_updated', memory: newMem };
         }
       }
@@ -441,7 +490,7 @@ export class MemoryWriter {
       return gateResults.map(r => r || { action: 'skipped' });
     }
 
-    const { smartUpdate, exactDupThreshold, similarityThreshold } = this.config.sieve;
+    const { smartUpdate, exactDupThreshold } = this.config.sieve;
 
     // Phase 1: find similar for each extraction, classify into tiers
     interface PendingItem {
@@ -455,11 +504,8 @@ export class MemoryWriter {
     // Phase 1: parallel findSimilar for all gated extractions
     const similarResults = await Promise.all(
       gatedExtractions.map(ext => {
-        const cats = ext.category === 'correction'
-          ? ['identity', 'fact', 'preference', 'decision', 'entity', 'skill', 'relationship', 'goal', 'project_state', 'correction']
-          : undefined;
-        // Corrections get wider search (top 10) to find the target memory
-        const topK = ext.category === 'correction' ? 10 : 3;
+        const cats = this.getSearchCategories(ext.category);
+        const topK = this.getSearchTopK(ext.category);
         return this.findSimilar(ext.content, agentId, cats, topK);
       }),
     );
@@ -468,9 +514,7 @@ export class MemoryWriter {
     for (let i = 0; i < gatedExtractions.length; i++) {
       const extraction = gatedExtractions[i]!;
       const similar = similarResults[i]!;
-      const effectiveThreshold = extraction.category === 'correction'
-        ? Math.min(similarityThreshold * 1.5, 0.6)
-        : similarityThreshold;
+      const effectiveThreshold = this.getEffectiveThreshold(extraction.category);
 
       if (!smartUpdate) {
         if (similar.length > 0 && similar[0]!.distance < 0.15) {
@@ -529,6 +573,14 @@ export class MemoryWriter {
             { action: 'replace', reasoning: 'Near-exact match, auto-replaced without LLM' },
             item.closest!.memory, item.extraction, agentId, sessionId, confidenceOverride, sourcePrefix,
           );
+          if (item.extraction.category === 'correction') {
+            this.cascadeCorrectionStateSupersedes(
+              newMem.id,
+              item.similar,
+              item.closest!.memory.id,
+              this.getEffectiveThreshold(item.extraction.category),
+            );
+          }
           batchResults[item.index] = { action: 'smart_updated', memory: newMem };
           break;
         }
@@ -541,6 +593,14 @@ export class MemoryWriter {
             const newMem = await this.executeSmartUpdate(
               decision, item.closest!.memory, item.extraction, agentId, sessionId, confidenceOverride, sourcePrefix,
             );
+            if (item.extraction.category === 'correction') {
+              this.cascadeCorrectionStateSupersedes(
+                newMem.id,
+                item.similar,
+                item.closest!.memory.id,
+                this.getEffectiveThreshold(item.extraction.category),
+              );
+            }
             batchResults[item.index] = { action: 'smart_updated', memory: newMem };
           }
           break;

--- a/packages/server/src/core/sieve.ts
+++ b/packages/server/src/core/sieve.ts
@@ -344,7 +344,6 @@ export class MemorySieve {
               confidence: rel.confidence,
               source_memory_id: firstMemoryId || undefined,
               agent_id: agentId,
-              pairing_code: pairingCode,
               source: 'extraction',
               extraction_count: 1,
               expired: rel.expired ? 1 : 0,
@@ -358,7 +357,6 @@ export class MemorySieve {
               confidence: rel.confidence,
               source_memory_id: firstMemoryId,
               agent_id: agentId,
-              pairing_code: pairingCode,
               source: 'extraction',
               expired: rel.expired ? 1 : 0,
             });

--- a/packages/server/src/db/neo4j.ts
+++ b/packages/server/src/db/neo4j.ts
@@ -2,6 +2,7 @@
  * Neo4j graph database connection and relation queries.
  * Replaces SQLite-based relation storage with native graph operations.
  */
+import { createHash } from 'crypto';
 import neo4j, { Driver, Session } from 'neo4j-driver';
 
 let driver: Driver | null = null;
@@ -67,24 +68,97 @@ export interface GraphRelation {
   updated_at: string;
 }
 
+export function buildRelationSemanticId(rel: Pick<GraphRelation, 'subject' | 'predicate' | 'object' | 'agent_id'>): string {
+  return createHash('sha1')
+    .update(`${rel.agent_id}\u0000${rel.subject}\u0000${rel.predicate}\u0000${rel.object}`)
+    .digest('hex');
+}
+
 export async function upsertRelation(rel: Omit<GraphRelation, 'created_at' | 'updated_at'>): Promise<void> {
   if (!driver) return;
   const session = driver.session();
   const now = new Date().toISOString();
   const relType = rel.predicate.toUpperCase().replace(/[\s-]/g, '_');
+  const semanticId = buildRelationSemanticId(rel);
 
   try {
     await session.run(`
       MERGE (s:Entity {name: $subject})
       MERGE (o:Entity {name: $object})
-      MERGE (s)-[r:${relType} {id: $id}]->(o)
-      ON CREATE SET r.confidence = $confidence, r.agent_id = $agentId, r.source = $source,
-                    r.source_memory_id = $sourceMemoryId, r.extraction_count = $extractionCount,
-                    r.expired = $expired, r.created_at = $now, r.updated_at = $now
-      ON MATCH SET r.confidence = $confidence, r.extraction_count = r.extraction_count + 1,
-                   r.expired = $expired, r.updated_at = $now
     `, {
-      id: rel.id,
+      subject: rel.subject,
+      object: rel.object,
+    });
+
+    const existing = await session.run(`
+      MATCH (s:Entity {name: $subject})-[r:${relType}]->(o:Entity {name: $object})
+      WHERE r.agent_id = $agentId
+      RETURN elementId(r) AS element_id
+      ORDER BY r.updated_at DESC, r.created_at DESC
+    `, {
+      subject: rel.subject,
+      object: rel.object,
+      agentId: rel.agent_id,
+    });
+
+    if (existing.records.length > 0) {
+      const keepElementId = existing.records[0]!.get('element_id') as string;
+      const duplicateElementIds = existing.records.slice(1).map(r => r.get('element_id') as string);
+
+      await session.run(`
+        MATCH (s:Entity {name: $subject})-[r:${relType}]->(o:Entity {name: $object})
+        WHERE elementId(r) = $keepElementId
+        SET r.id = coalesce(r.id, $semanticId),
+            r.semantic_id = $semanticId,
+            r.confidence = $confidence,
+            r.agent_id = $agentId,
+            r.source = $source,
+            r.source_memory_id = coalesce($sourceMemoryId, r.source_memory_id),
+            r.extraction_count = coalesce(r.extraction_count, 0) + $extractionCount,
+            r.expired = $expired,
+            r.created_at = coalesce(r.created_at, $now),
+            r.updated_at = $now
+      `, {
+        keepElementId,
+        semanticId,
+        subject: rel.subject,
+        object: rel.object,
+        confidence: rel.confidence,
+        agentId: rel.agent_id,
+        source: rel.source,
+        sourceMemoryId: rel.source_memory_id || null,
+        extractionCount: neo4j.int(rel.extraction_count),
+        expired: neo4j.int(rel.expired),
+        now,
+      });
+
+      if (duplicateElementIds.length > 0) {
+        await session.run(`
+          MATCH ()-[r]->()
+          WHERE elementId(r) IN $duplicateElementIds
+          DELETE r
+        `, { duplicateElementIds });
+      }
+      return;
+    }
+
+    await session.run(`
+      MATCH (s:Entity {name: $subject})
+      MATCH (o:Entity {name: $object})
+      CREATE (s)-[r:${relType} {
+        id: $semanticId,
+        semantic_id: $semanticId,
+        confidence: $confidence,
+        agent_id: $agentId,
+        source: $source,
+        source_memory_id: $sourceMemoryId,
+        extraction_count: $extractionCount,
+        expired: $expired,
+        created_at: $now,
+        updated_at: $now
+      }]->(o)
+    `, {
+      semanticId,
       subject: rel.subject,
       object: rel.object,
       confidence: rel.confidence,
@@ -222,7 +296,7 @@ export async function traverseRelations(entityName: string, opts: {
 export async function findShortestPath(from: string, to: string, opts: {
   maxHops?: number;
   agentId?: string;
-}): Promise<{ path: { entity: string; predicate?: string }[]; hops: number }> {
+}): Promise<{ path: { entity?: string; predicate?: string }[]; hops: number }> {
   if (!driver) return { path: [], hops: 0 };
   const session = driver.session();
   const maxHops = opts.maxHops || 5;
@@ -242,7 +316,7 @@ export async function findShortestPath(from: string, to: string, opts: {
     const hops = typeof result.records[0]!.get('hops')?.toNumber === 'function'
       ? result.records[0]!.get('hops').toNumber() : result.records[0]!.get('hops');
 
-    const path: { entity: string; predicate?: string }[] = [];
+    const path: { entity?: string; predicate?: string }[] = [];
     for (let i = 0; i < entities.length; i++) {
       path.push({ entity: entities[i]! });
       if (i < predicates.length) {

--- a/packages/server/tests/db.test.ts
+++ b/packages/server/tests/db.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initDatabase, closeDatabase, getDb } from '../src/db/index.js';
 import { loadConfig } from '../src/utils/config.js';
+import { buildRelationSemanticId } from '../src/db/neo4j.js';
 import {
   insertMemory,
   getMemoryById,
@@ -136,6 +137,15 @@ describe('Database', () => {
       const list = listRelations({ subject: 'Harry' });
       expect(list.length).toBeGreaterThanOrEqual(1);
       expect(list.find(r => r.predicate === 'lives_in')).toBeDefined();
+    });
+
+    it('should build stable semantic ids for the same relation tuple', () => {
+      const a = buildRelationSemanticId({ subject: '用户', predicate: 'prefers', object: 'TypeScript', agent_id: 'saki' } as any);
+      const b = buildRelationSemanticId({ subject: '用户', predicate: 'prefers', object: 'TypeScript', agent_id: 'saki' } as any);
+      const c = buildRelationSemanticId({ subject: '用户', predicate: 'prefers', object: 'TypeScript', agent_id: 'main' } as any);
+
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
     });
 
     it('should delete relations', () => {

--- a/packages/server/tests/sieve.test.ts
+++ b/packages/server/tests/sieve.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { initDatabase, closeDatabase } from '../src/db/index.js';
+import { insertMemory, getMemoryById, listMemories } from '../src/db/queries.js';
 import { loadConfig } from '../src/utils/config.js';
 import { MemorySieve } from '../src/core/sieve.js';
 import type { LLMProvider } from '../src/llm/interface.js';
@@ -250,5 +251,74 @@ describe('MemorySieve', () => {
     // Should detect duplicate and increment deduplicated count
     expect(result.deduplicated).toBeGreaterThanOrEqual(0);
     expect(result.extracted).toBeDefined();
+  });
+
+  it('should let correction supersede related todo and decision state memories', async () => {
+    const config = loadConfig({
+      storage: { dbPath: ':memory:', walMode: false },
+      markdownExport: { enabled: false, exportMemoryMd: false, debounceMs: 999999 },
+    });
+
+    const decision = insertMemory({
+      layer: 'core',
+      category: 'decision',
+      content: '用户已决定将VTuber RSS Digest任务中的模型更新为 cch-gemini/gemini-3-flash-preview，并计划重建new-api',
+      agent_id: 'saki',
+      importance: 0.9,
+    });
+    const todo = insertMemory({
+      layer: 'working',
+      category: 'todo',
+      content: '用户计划重建new-api以解决模型更换问题',
+      agent_id: 'saki',
+      importance: 0.7,
+    });
+    const preference = insertMemory({
+      layer: 'core',
+      category: 'preference',
+      content: '偏好使用 cch-gemini/gemini-3-flash-preview 模型进行任务处理',
+      agent_id: 'saki',
+      importance: 0.8,
+    });
+
+    const correctionLLM: LLMProvider = {
+      name: 'mock-correction',
+      complete: vi.fn().mockResolvedValue(JSON.stringify({
+        memories: [
+          {
+            content: '纠正：VTuber RSS Digest 任务切换到 cch-gemini/gemini-3-flash-preview 已经完成，new-api 也已经重建完成；“计划重建 new-api”不再是待办状态。',
+            category: 'correction',
+            importance: 0.95,
+            source: 'user_stated',
+            reasoning: '用户明确说明旧计划状态已完成，应覆盖旧状态记忆',
+          },
+        ],
+        nothing_extracted: false,
+      })),
+    };
+
+    const mockVector = createMockVector();
+    mockVector.search = vi.fn().mockResolvedValue([
+      { id: decision.id, distance: 0.18 },
+      { id: todo.id, distance: 0.21 },
+      { id: preference.id, distance: 0.24 },
+    ] as any);
+
+    const sieve = new MemorySieve(correctionLLM, createMockEmbedding(), mockVector, config);
+    const result = await sieve.ingest({
+      user_message: '这个早就已经修改完了，而且我已经重建完了',
+      assistant_message: '收到，我会更新记忆状态',
+      agent_id: 'saki',
+    });
+
+    const correctionMemory = result.extracted.find(m => m.category === 'correction');
+    expect(correctionMemory).toBeDefined();
+
+    expect(getMemoryById(decision.id)?.superseded_by).toBe(correctionMemory!.id);
+    expect(getMemoryById(todo.id)?.superseded_by).toBe(correctionMemory!.id);
+    expect(getMemoryById(preference.id)?.superseded_by).toBeFalsy();
+
+    const activeTodos = listMemories({ agent_id: 'saki' }).items.filter(m => m.category === 'todo' && !m.superseded_by);
+    expect(activeTodos.some(m => m.id === todo.id)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes two memory-governance bugs that show up in real long-running usage:

1. **Neo4j relation upsert was not actually deduplicating**
   - Relation writes used a fresh random UUID on every upsert.
   - The Neo4j `MERGE` key was effectively `id`, so repeated extractions of the same `(subject, predicate, object, agent_id)` created duplicate edges instead of updating a single relation.
   - This PR switches relation identity to a stable semantic ID and consolidates legacy duplicate edges when an existing semantic match is found.

2. **`correction` memories could not close stale `todo` state**
   - Correction search did not include `todo`, `constraint`, or `policy`, so completed/corrected project state could remain active and keep misleading recall.
   - This PR expands correction search coverage and adds a conservative cascade that supersedes only related **state-like** memories (`todo`, `decision`, `goal`, `project_state`, `correction`) while leaving higher-risk categories like `identity` / `preference` untouched.

## Changes

- Add `buildRelationSemanticId()` for stable relation identity
- Update Neo4j relation upsert to:
  - find existing semantic matches by `(subject, predicate, object, agent_id)`
  - reuse/update a single edge
  - delete extra duplicate edges when present
- Expand correction similarity search categories
- Cascade correction supersede only for state-like categories
- Add regression tests for:
  - stable semantic relation IDs
  - correction superseding related `todo` / `decision` while not touching unrelated `preference`

## Validation

### Targeted tests

```bash
corepack pnpm -C /root/cortex/packages/server exec vitest run tests/db.test.ts tests/sieve.test.ts
```

Result: **29/29 passed**

### Live Neo4j sanity check

Repeated upsert of the same isolated test tuple now stays at **1 edge** and increments `extraction_count` instead of creating duplicates.

## Notes

I also re-ran broader local checks and saw pre-existing baseline failures unrelated to this patch (for example existing full-repo lint/type issues and unrelated red tests such as dashboard dist / Japanese identity signal detection in my local environment). I did **not** change those in this PR.
